### PR TITLE
Fix version features 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,9 @@ gtk-layer-shell-sys = "0.2"
 
 [dev-dependencies]
 gio = "0.14"
+
+[features]
+v0_4 = ["gtk-layer-shell-sys/v0_4"]
+v0_5 = ["v0_4", "gtk-layer-shell-sys/v0_5"]
+v0_6 = ["v0_5", "gtk-layer-shell-sys/v0_6"]
+dox = []

--- a/gtk-layer-shell-sys/Gir.toml
+++ b/gtk-layer-shell-sys/Gir.toml
@@ -11,3 +11,9 @@ external_libraries = [
     "Gdk",
     "Gtk",
 ]
+
+[[object]]
+name = "GtkLayerShell.*"
+    [[object.function]]
+    name = "get_zwlr_layer_surface_v1"
+    ignore = true

--- a/gtk-layer-shell-sys/src/lib.rs
+++ b/gtk-layer-shell-sys/src/lib.rs
@@ -85,9 +85,6 @@ extern "C" {
     #[cfg(any(feature = "v0_6", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v0_6")))]
     pub fn gtk_layer_get_protocol_version() -> c_uint;
-    #[cfg(any(feature = "v0_4", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4")))]
-    pub fn gtk_layer_get_zwlr_layer_surface_v1(window: *mut gtk::GtkWindow) -> *mut zwlr_layer_surface_v1;
     pub fn gtk_layer_init_for_window(window: *mut gtk::GtkWindow);
     #[cfg(any(feature = "v0_5", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v0_5")))]


### PR DESCRIPTION
- gtk-layer-shell-sys
  - ignore `gtk_layer_get_zwlr_layer_surface_v1` to make the build pass with `v0_4` flag
- gtk-layer-shell
  - expose version feature flags to the user